### PR TITLE
Daltonize mpl

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,25 +1,41 @@
 # Daltonize
 
-Daltonize simulates the three types of dichromatic color
-blindness. Generalizing and omitting a lot of details these are:
+Daltonize simulates the three types of dichromatic color blindness and
+images and matplotlib figures. Generalizing and omitting a lot of
+details these types are:
 
 * Deuteranopia: green weakness
 * Protanopia: red weakness
 * Tritanopia: blue weakness (extremely rare)
 
 Daltonize can also adjust the color palette of an input image such
-that a color blind person can perceive the full information content.
+that a color blind person can perceive the full information
+content. It can be used as a command line tool to convert pixel images
+but also as a Python module. If used as the latter, it provides an API
+to simulate and correct for color blindness in matplotlib figures.
+
+This allows to create color blind friendly vector graphics suitable
+for publication.
 
 ## Installation
 
 $ git clone git@github.com:joergdietrich/daltonize.git
 
-and copy daltonize.py to a location in your $PATH. Daltonize depends
+and copy daltonize.py to a location in your $PATH and/or
+$PYTHONPATH. Daltonize depends
 
 * Pillow: https://python-pillow.github.io/
 * numpy: http://www.numpy.org/
 
+and
+
+* matplotlib: http://matplotlib.org/
+
+if it is used to work on matplotlib figure objects.
+
 ## Usage
+
+As a command line tool:
 
 ```
 $ daltonize.py -h
@@ -36,6 +52,18 @@ optional arguments:
   -t {d,p,t}, --type {d,p,t}
                         type of color blindness (deuteranopia, protanopia,
                         tritanopia), default is deuteranopia (most common)
+```
+
+As a Python module:
+
+```
+In [1]: import daltonize
+
+[ Create a figure ]
+
+In [10]: sim_fig = daltonize.simulate_mpl(fig, copy=True)
+
+In [11]: daltonized_fig = daltonize.daltonize_mpl(fig, copy=True)
 ```
 
 ## Credits

--- a/daltonize.py
+++ b/daltonize.py
@@ -260,8 +260,10 @@ def set_colors_from_array(instance, mpl_colors, rgba, i=0):
                 continue
             color_shape = cc.to_rgba_array(color).shape
             j = color_shape[0]
-            target_color = rgba[i:i+j, :].reshape(j, 4)
-            target_color = target_color[0]
+            print(color_shape)
+            target_color = rgba[i:i+j, :]
+            if j == 1:
+                target_color = target_color[0]
             i += j
             if color_key == "color":
                 instance.set_color(target_color)

--- a/daltonize.py
+++ b/daltonize.py
@@ -128,13 +128,13 @@ def array_to_img(arr):
         RGB image created from array
     """
     # clip values to lie in the range [0, 255]
-    arr = clip_arrary(arr)
+    arr = clip_array(arr)
     arr = arr.astype('uint8')
     img = Image.fromarray(arr, mode='RGB')
     return img
 
 
-def clip_arrary(arr, min_value=0, max_value=255):
+def clip_array(arr, min_value=0, max_value=255):
     """Ensure that all values in an array are between min and max values.
 
     Arguments:
@@ -323,7 +323,7 @@ def _prepare_call_sim(fig, color_deficit):
 
 
 def _join_rgb_alpha(rgb, alpha):
-    rgb = clip_arrary(rgb, 0, 1)
+    rgb = clip_array(rgb, 0, 1)
     r, g, b = np.split(rgb, 3, 2)
     rgba = np.concatenate((r, g, b, alpha.reshape(alpha.size, 1, 1)),
                           axis=2).reshape(-1, 4)

--- a/daltonize.py
+++ b/daltonize.py
@@ -8,11 +8,21 @@
 
 from __future__ import print_function, division
 
+from collections import OrderedDict
 import os
-
+try:
+    import pickle
+except ImportError:
+    import cPickle as pickle
+    
 from PIL import Image
 import numpy as np
-
+try:
+    import matplotlib as mpl
+    _no_mpl = False
+except ImportError:
+    _no_mpl = True
+    
 
 def transform_colorspace(img, mat):
     """Transform image to a different color space.
@@ -127,6 +137,187 @@ def array_to_img(arr):
     return img
 
 
+def get_child_colors(child, mpl_colors):
+    """
+    Recursively enter all colors of a matplotlib objects and its
+    children into a dictionary.
+    
+    Arguments:
+    ----------
+    child : a matplotlib object
+    mpl_colors : OrderedDict from collections
+
+    Returns:
+    --------
+    mpl_colors : OrderedDict
+    """
+    mpl_colors[child] = OrderedDict()
+    # does not deal with cmaps yet, only with lines, patches,
+    # etc. (vector like stuff)
+    if hasattr(child, "get_color"):
+        mpl_colors[child]['color'] = child.get_color()
+    if hasattr(child, "get_facecolor"):
+        mpl_colors[child]['fc'] = child.get_facecolor()
+    if hasattr(child, "get_edgecolor"):
+        mpl_colors[child]['ec'] = child.get_edgecolor()
+    if hasattr(child, "get_markeredgecolor"):
+        mpl_colors[child]['mec'] = child.get_markeredgecolor()
+    if hasattr(child, "get_markerfacecolor"):
+        mpl_colors[child]['mfc'] = child.get_markerfacecolor()
+    if hasattr(child, "get_markerfacecoloralt"):
+        mpl_colors[child]['mfcalt'] = child.get_markerfacecoloralt()
+    if hasattr(child, "get_children"):
+        grandchildren = child.get_children()
+        for grandchild in grandchildren:
+            mpl_colors = get_child_colors(grandchild, mpl_colors)
+    return mpl_colors
+
+
+def get_mpl_colors(fig):
+    """
+    Read all colors used in a matplotlib figure into an OrderedDict.
+
+    Arguments:
+    ----------
+    fig : matplotlib.figure.Figure
+
+    Returns:
+    --------
+    mpl_dict : OrderedDict from collections
+    """
+    mpl_colors = OrderedDict()
+    children = fig.get_children()
+    for child in children:
+        mpl_colors = get_child_colors(child, mpl_colors)
+    return mpl_colors
+
+
+def get_key_colors(mpl_colors, rgb, alpha):
+    if _no_mpl == True:
+        raise ImportError("matplotlib not found, " \
+                          "can only deal with pixel images")
+    cc = mpl.colors.ColorConverter()
+    # Note that the order must match the insertion order in
+    # get_child_colors()
+    color_keys = ("color", "fc", "ec", "mec", "mfc", "mfcalt")
+    for color_key in color_keys:
+        try:
+            color = mpl_colors[color_key]
+            # skip unset colors, otherwise they are turned into black.
+            if color == 'none':
+                continue
+            rgba = cc.to_rgba_array(color)
+            rgb = np.append(rgb, rgba[:, :3])
+            alpha = np.append(alpha, rgba[:, 3])
+        except KeyError:
+            pass
+        for key in mpl_colors.keys():
+            if key in color_keys:
+                continue
+            rgb, alpha = get_key_colors(mpl_colors[key], rgb, alpha)
+    return rgb, alpha
+
+
+def arrays_from_dict(mpl_colors):
+    """
+    Create rgb and alpha arrays from color dictionary.
+
+    Arguments:
+    ----------
+    mpl_colors : OrderedDict
+        dictionary with all colors of all children, matplotlib instances are
+        keys
+
+    Returns:
+    --------
+    rgb : array of shape (M, 1, 3)
+        RGB values of colors in a line image, M is the total number of 
+        non-unique colors
+    alpha : array of shape (M, 1)
+        Alpha channel values of all mpl instances
+    """
+    rgb = np.array([])
+    alpha = np.array([])
+    for key in mpl_colors.keys():
+        rgb, alpha = get_key_colors(mpl_colors[key], rgb, alpha)
+    m = rgb.size / 3
+    rgb = rgb.reshape((m, 1, 3))
+    return rgb, alpha
+
+
+def replace_mpl_colors(mpl_colors, rgba, i=0):
+    """
+    """
+    for key in mpl_colors.keys():
+        i = set_color_values(mpl_colors[key], rgba, i)
+
+        
+def set_color_values(mpl_colors, rgba, i):
+    cc = mpl.colors.ColorConverter()
+    # Note that the order must match the insertion order in
+    # get_child_colors()
+    color_keys = ("color", "fc", "ec", "mec", "mfc", "mfcalt")
+    for color_key in color_keys:
+        try:
+            color = mpl_colors[color_key]
+            # skip unset colors, otherwise they are turned into black.
+            if color == 'none':
+                continue
+            color_shape = cc.to_rgba_array(color).shape
+            if len(color_shape) > 1:
+                j = color_shape[0]
+            else:
+                j = 1
+            mpl_colors[color_key] = rgba[i:i+j, :].reshape(j, 4)
+            i += j
+        except KeyError:
+            pass
+        for key in mpl_colors.keys():
+            if key in color_keys:
+                continue
+            i = set_color_values(mpl_colors[key], rgba, i)
+    return i
+                    
+
+def simulate_mpl(fig, color_deficit='d', copy=False):
+    """
+    fig : matplotlib.figure.Figure
+    color_deficit : {"d", "p", "t"}, optional
+        type of colorblindness, d for deuteronopia (default),
+        p for protonapia,
+        t for tritanopia
+    copy : bool, optional
+        should simulation happen on a copy (True) or the original 
+        (False, default)
+
+    Returns:
+    --------
+    fig : matplotlib.figure.Figure
+    """
+    if copy:
+        # mpl.transforms cannot be copy.deepcopy()ed. Thus we resort
+        # to pickling.
+        # Turns out PolarAffine cannot be unpickled ...
+        pfig = pickle.dumps(fig)
+        fig = pickle.loads(pfig)
+    mpl_colors = get_mpl_colors(fig)
+    rgb, alpha = arrays_from_dict(mpl_colors)
+    sim_rgb = simulate(array_to_img(rgb), color_deficit)
+    # clip values to lie in the range [0, 1]
+    comp_arr1 = np.zeros_like(sim_rgb)
+    comp_arr2 = np.ones_like(sim_rgb)
+    sim_rgb = np.maximum(comp_arr1, sim_rgb)
+    sim_rgb = np.minimum(comp_arr2, sim_rgb)
+
+    r, g, b = np.split(sim_rgb, 3, 2)
+    rgba = np.concatenate((r, g, b, alpha.reshape(alpha.size, 1, 1)),
+                           axis=2).reshape(-1, 4)
+    replace_mpl_colors(mpl_colors, rgba)
+    set_mpl_colors(mpl_colors, rgba)
+    fig.canvas.draw()
+    return fig
+    
+    
 if __name__ == '__main__':
     import argparse
     import sys
@@ -151,7 +342,7 @@ if __name__ == '__main__':
         args.daltonize = True
     if args.type is None:
         args.type = "d"
-        
+
     orig_img = Image.open(args.input_image)
     sim_rgb, rgb = simulate(orig_img, args.type, return_original_rgb=True)
     if args.simulate:

--- a/daltonize.py
+++ b/daltonize.py
@@ -264,9 +264,7 @@ def arrays_from_dict(mpl_colors):
     return rgb, alpha
 
 
-def set_colors_from_array(instance, mpl_colors, rgba, i=0):
-    """
-    """
+def _set_colors_from_array(instance, mpl_colors, rgba, i=0):
     cc = mpl.colors.ColorConverter()
     # Note that the order must match the insertion order in
     # get_child_colors()
@@ -297,19 +295,24 @@ def set_colors_from_array(instance, mpl_colors, rgba, i=0):
                 instance.set_markerfacecoloralt(target_color)
         except KeyError:
             pass
-        for key in mpl_colors.keys():
-            if key in color_keys:
-                continue
-            i = set_mpl_colors(key, mpl_colors[key], rgba, i)
     return i
 
 
 def set_mpl_colors(mpl_colors, rgba):
     """
+    Recursively set the colors in a color dictionary to new values in rgba.
+
+    Arguments:
+    ----------
+    mpl_colors : OrderedDict
+        dictionary with all colors of all children, matplotlib instances are
+        keys
+
+    rgba : array of shape (M, 1, 4) containing rgb, alpha channels
     """
     i = 0
     for key in mpl_colors.keys():
-        i = set_colors_from_array(key, mpl_colors[key], rgba, i)
+        i = _set_colors_from_array(key, mpl_colors[key], rgba, i)
 
 
 def _prepare_call_sim(fig, color_deficit):
@@ -331,6 +334,8 @@ def simulate_mpl(fig, color_deficit='d', copy=False):
     """
     Simulate color blindness on a matplotlib figure.
 
+    Arguments:
+    ----------
     fig : matplotlib.figure.Figure
     color_deficit : {"d", "p", "t"}, optional
         type of colorblindness, d for deuteronopia (default),
@@ -361,6 +366,8 @@ def daltonize_mpl(fig, color_deficit='d', copy=False):
     """
     Daltonize a matplotlib figure.
 
+    Arguments:
+    ----------
     fig : matplotlib.figure.Figure
     color_deficit : {"d", "p", "t"}, optional
         type of colorblindness, d for deuteronopia (default),

--- a/daltonize.py
+++ b/daltonize.py
@@ -14,7 +14,7 @@ try:
     import pickle
 except ImportError:
     import cPickle as pickle
-    
+
 from PIL import Image
 import numpy as np
 try:
@@ -22,7 +22,7 @@ try:
     _no_mpl = False
 except ImportError:
     _no_mpl = True
-    
+
 
 def transform_colorspace(img, mat):
     """Transform image to a different color space.
@@ -160,7 +160,7 @@ def get_child_colors(child, mpl_colors):
     """
     Recursively enter all colors of a matplotlib objects and its
     children into a dictionary.
-    
+
     Arguments:
     ----------
     child : a matplotlib object
@@ -212,8 +212,8 @@ def get_mpl_colors(fig):
 
 
 def get_key_colors(mpl_colors, rgb, alpha):
-    if _no_mpl == True:
-        raise ImportError("matplotlib not found, " \
+    if _no_mpl is True:
+        raise ImportError("matplotlib not found, "
                           "can only deal with pixel images")
     cc = mpl.colors.ColorConverter()
     # Note that the order must match the insertion order in
@@ -250,7 +250,7 @@ def arrays_from_dict(mpl_colors):
     Returns:
     --------
     rgb : array of shape (M, 1, 3)
-        RGB values of colors in a line image, M is the total number of 
+        RGB values of colors in a line image, M is the total number of
         non-unique colors
     alpha : array of shape (M, 1)
         Alpha channel values of all mpl instances
@@ -305,6 +305,8 @@ def set_colors_from_array(instance, mpl_colors, rgba, i=0):
 
 
 def set_mpl_colors(mpl_colors, rgba):
+    """
+    """
     i = 0
     for key in mpl_colors.keys():
         i = set_colors_from_array(key, mpl_colors[key], rgba, i)
@@ -327,13 +329,15 @@ def _join_rgb_alpha(rgb, alpha):
 
 def simulate_mpl(fig, color_deficit='d', copy=False):
     """
+    Simulate color blindness on a matplotlib figure.
+
     fig : matplotlib.figure.Figure
     color_deficit : {"d", "p", "t"}, optional
         type of colorblindness, d for deuteronopia (default),
         p for protonapia,
         t for tritanopia
     copy : bool, optional
-        should simulation happen on a copy (True) or the original 
+        should simulation happen on a copy (True) or the original
         (False, default)
 
     Returns:
@@ -351,17 +355,19 @@ def simulate_mpl(fig, color_deficit='d', copy=False):
     set_mpl_colors(mpl_colors, rgba)
     fig.canvas.draw()
     return fig
-    
+
 
 def daltonize_mpl(fig, color_deficit='d', copy=False):
     """
+    Daltonize a matplotlib figure.
+
     fig : matplotlib.figure.Figure
     color_deficit : {"d", "p", "t"}, optional
         type of colorblindness, d for deuteronopia (default),
         p for protonapia,
         t for tritanopia
     copy : bool, optional
-        should simulation happen on a copy (True) or the original 
+        should daltonization happen on a copy (True) or the original
         (False, default)
 
     Returns:
@@ -380,8 +386,8 @@ def daltonize_mpl(fig, color_deficit='d', copy=False):
     set_mpl_colors(mpl_colors, rgba)
     fig.canvas.draw()
     return fig
-   
-    
+
+
 if __name__ == '__main__':
     import argparse
     import sys
@@ -391,9 +397,9 @@ if __name__ == '__main__':
     parser.add_argument("output_image", type=str)
     group = parser.add_mutually_exclusive_group()
     group.add_argument("-s", "--simulate", help="create simulated image",
-                        action="store_true")
+                       action="store_true")
     group.add_argument("-d", "--daltonize",
-                        help="adjust image color palette for color blindness",
+                       help="adjust image color palette for color blindness",
                        action="store_true")
     parser.add_argument("-t", "--type", type=str, choices=["d", "p", "t"],
                         help="type of color blindness (deuteranopia, "

--- a/daltonize.py
+++ b/daltonize.py
@@ -260,7 +260,6 @@ def set_colors_from_array(instance, mpl_colors, rgba, i=0):
                 continue
             color_shape = cc.to_rgba_array(color).shape
             j = color_shape[0]
-            print(color_shape)
             target_color = rgba[i:i+j, :]
             if j == 1:
                 target_color = target_color[0]


### PR DESCRIPTION
Routines to simulate color blindness and ensure correct display for matplotlib.figure.Figure objects.
Does not work on colormaps yet.
