### PR TITLE
Img interface

### DIFF
--- a/daltonize.py
+++ b/daltonize.py
@@ -12,7 +12,7 @@ from collections import OrderedDict
 try:
     import pickle
 except ImportError:
-    import cPickle as pickle # pylint: disable=import-error
+    import cPickle as pickle  # pylint: disable=import-error
 
 from PIL import Image
 import numpy as np
@@ -239,7 +239,7 @@ def get_key_colors(mpl_colors, rgb, alpha):
     if _NO_MPL is True:
         raise ImportError("matplotlib not found, "
                           "can only deal with pixel images")
-    cc = mpl.colors.ColorConverter() # pylint: disable=invalid-name
+    cc = mpl.colors.ColorConverter()  # pylint: disable=invalid-name
     # Note that the order must match the insertion order in
     # get_child_colors()
     color_keys = ("color", "fc", "ec", "mec", "mfc", "mfcalt", "cmap", "array")
@@ -253,7 +253,7 @@ def get_key_colors(mpl_colors, rgb, alpha):
                 rgba = color(np.arange(color.N))
             elif isinstance(color, np.ndarray) and color_key == "array":
                 color = color.reshape(-1, 3) / 255
-                a = np.zeros((color.shape[0], 1)) # pylint: disable=invalid-name
+                a = np.zeros((color.shape[0], 1))  # pylint: disable=invalid-name
                 rgba = np.hstack((color, a))
             else:
                 rgba = cc.to_rgba_array(color)
@@ -290,7 +290,7 @@ def arrays_from_dict(mpl_colors):
     alpha = np.array([])
     for key in mpl_colors.keys():
         rgb, alpha = get_key_colors(mpl_colors[key], rgb, alpha)
-    m = rgb.size / 3 # pylint: disable=invalid-name
+    m = rgb.size / 3  # pylint: disable=invalid-name
     rgb = rgb.reshape((m, 1, 3))
     return rgb, alpha
 
@@ -299,7 +299,7 @@ def _set_colors_from_array(instance, mpl_colors, rgba, i=0):
     """
     Set object instance colors to the modified ones in rgba.
     """
-    cc = mpl.colors.ColorConverter() # pylint: disable=invalid-name
+    cc = mpl.colors.ColorConverter()  # pylint: disable=invalid-name
     # Note that the order must match the insertion order in
     # get_child_colors()
     color_keys = ("color", "fc", "ec", "mec", "mfc", "mfcalt", "cmap", "array")
@@ -380,7 +380,7 @@ def _join_rgb_alpha(rgb, alpha):
     Combine (m, n, 3) rgb and (m, n) alpha array into (m, n, 4) rgba.
     """
     rgb = clip_array(rgb, 0, 1)
-    r, g, b = np.split(rgb, 3, 2) # pylint: disable=invalid-name, unbalanced-tuple-unpacking
+    r, g, b = np.split(rgb, 3, 2)  # pylint: disable=invalid-name, unbalanced-tuple-unpacking
     rgba = np.concatenate((r, g, b, alpha.reshape(alpha.size, 1, 1)),
                           axis=2).reshape(-1, 4)
     return rgba

--- a/daltonize.py
+++ b/daltonize.py
@@ -18,9 +18,9 @@ from PIL import Image
 import numpy as np
 try:
     import matplotlib as mpl
-    _no_mpl = False
+    _NO_MPL = False
 except ImportError:
-    _no_mpl = True
+    _NO_MPL = True
 
 
 def transform_colorspace(img, mat):
@@ -40,7 +40,7 @@ def transform_colorspace(img, mat):
     return np.einsum("ij, ...j", mat, img)
 
 
-def simulate(img, color_deficit="d", return_original_rgb=False):
+def simulate(img, color_deficit="d"):
     """Simulate the effect of color blindness on an image.
 
     Arguments:
@@ -50,8 +50,6 @@ def simulate(img, color_deficit="d", return_original_rgb=False):
         type of colorblindness, d for deuteronopia (default),
         p for protonapia,
         t for tritanopia
-    return_original_rgb : bool, optional
-        Return the original image as rgb if True, default False
 
     Returns:
     --------
@@ -85,12 +83,10 @@ def simulate(img, color_deficit="d", return_original_rgb=False):
     sim_lms = transform_colorspace(lms, cb_matrices[color_deficit])
     # Transform back to RBG
     sim_rgb = transform_colorspace(sim_lms, lms2rgb)
-    if return_original_rgb:
-        return sim_rgb, rgb
     return sim_rgb
 
 
-def daltonize(rgb, sim_rgb):
+def daltonize(rgb, color_deficit='d'):
     """
     Adjust color palette of an image to compensate color blindness.
 
@@ -98,13 +94,17 @@ def daltonize(rgb, sim_rgb):
     ----------
     rgb : array of shape (M, N, 3)
         original image in RGB format
-    sim_rgb : array of shape (M, N, 3)
-        image with simulated color blindness
+    color_deficit : {"d", "p", "t"}, optional
+        type of colorblindness, d for deuteronopia (default),
+        p for protonapia,
+        t for tritanopia
 
     Returns:
+    --------
     dtpn : array of shape (M, N, 3)
         image in RGB format with colors adjusted
     """
+    sim_rgb = simulate(rgb, color_deficit)
     err2mod = np.array([[0, 0, 0], [0.7, 1, 0], [0.7, 0, 1]])
     # rgb - sim_rgb contains the color information that dichromats
     # cannot see. err2mod rotates this to a part of the spectrum that
@@ -218,7 +218,7 @@ def get_mpl_colors(fig):
 
 
 def get_key_colors(mpl_colors, rgb, alpha):
-    if _no_mpl is True:
+    if _NO_MPL is True:
         raise ImportError("matplotlib not found, "
                           "can only deal with pixel images")
     cc = mpl.colors.ColorConverter() # pylint: disable=invalid-name
@@ -277,7 +277,7 @@ def arrays_from_dict(mpl_colors):
     return rgb, alpha
 
 
-def _set_colors_from_array(instance, mpl_colors, rgba, i=0):
+def _set_colors_from_array(instance, mpl_colors, rgba, i=0): #pylint: disable=missing-docstring
     cc = mpl.colors.ColorConverter() # pylint: disable=invalid-name
     # Note that the order must match the insertion order in
     # get_child_colors()
@@ -343,7 +343,7 @@ def set_mpl_colors(mpl_colors, rgba):
         i = _set_colors_from_array(key, mpl_colors[key], rgba, i)
 
 
-def _prepare_call_sim(fig, color_deficit):
+def _prepare_call_sim(fig, color_deficit): # pylint: disable=missing-docstring
     mpl_colors = get_mpl_colors(fig)
     rgb, alpha = arrays_from_dict(mpl_colors)
     sim_rgb = simulate(array_to_img(rgb * 255), color_deficit) / 255
@@ -351,6 +351,9 @@ def _prepare_call_sim(fig, color_deficit):
 
 
 def _join_rgb_alpha(rgb, alpha):
+    """
+    Combine (m, n, 3) rgb and (m, n) alpha array into (m, n, 4) rgba.
+    """
     rgb = clip_array(rgb, 0, 1)
     r, g, b = np.split(rgb, 3, 2) # pylint: disable=invalid-name, unbalanced-tuple-unpacking
     rgba = np.concatenate((r, g, b, alpha.reshape(alpha.size, 1, 1)),
@@ -449,11 +452,12 @@ if __name__ == '__main__':
         args.type = "d"
 
     orig_img = Image.open(args.input_image)
-    sim_rgb, rgb = simulate(orig_img, args.type, return_original_rgb=True)
+
     if args.simulate:
-        sim_img = array_to_img(sim_rgb)
-        sim_img.save(args.output_image)
+        simul_rgb = simulate(orig_img, args.type)
+        simul_img = array_to_img(simul_rgb)
+        simul_img.save(args.output_image)
     if args.daltonize:
-        dalton_rgb = daltonize(rgb, sim_rgb)
+        dalton_rgb = daltonize(orig_img, args.type)
         dalton_img = array_to_img(dalton_rgb)
         dalton_img.save(args.output_image)

--- a/daltonize.py
+++ b/daltonize.py
@@ -218,6 +218,24 @@ def get_mpl_colors(fig):
 
 
 def get_key_colors(mpl_colors, rgb, alpha):
+    """From an OrderedDict of colors of all figure object children
+    recursively fill rgb and alpha channel information.
+
+    Arguments:
+    ----------
+    mpl_colors : OrderedDict
+        dictionary with all colors of all children, matplotlib instances are
+        keys
+    rgb : array of shape (M, 1, 3)
+        line image holding RGB colors encountered so far.
+    alpha : array of shape (M, 1)
+        line image holding alpha values encountered so far.
+
+    Returns:
+    --------
+    rgb : array of shape (M+n, 1, 3)
+    alpha : array of shape (M+n, 1)
+    """
     if _NO_MPL is True:
         raise ImportError("matplotlib not found, "
                           "can only deal with pixel images")
@@ -277,7 +295,10 @@ def arrays_from_dict(mpl_colors):
     return rgb, alpha
 
 
-def _set_colors_from_array(instance, mpl_colors, rgba, i=0): #pylint: disable=missing-docstring
+def _set_colors_from_array(instance, mpl_colors, rgba, i=0):
+    """
+    Set object instance colors to the modified ones in rgba.
+    """
     cc = mpl.colors.ColorConverter() # pylint: disable=invalid-name
     # Note that the order must match the insertion order in
     # get_child_colors()
@@ -343,7 +364,11 @@ def set_mpl_colors(mpl_colors, rgba):
         i = _set_colors_from_array(key, mpl_colors[key], rgba, i)
 
 
-def _prepare_and_call_sim(fig, color_deficit): # pylint: disable=missing-docstring
+def _prepare_and_call_sim(fig, color_deficit):
+    """
+    Gather color keys/info for mpl figure and arange them such that the image
+    simulate() routine can be called on them.
+    """
     mpl_colors = get_mpl_colors(fig)
     rgb, alpha = arrays_from_dict(mpl_colors)
     sim_rgb = simulate(array_to_img(rgb * 255), color_deficit) / 255

--- a/daltonize.py
+++ b/daltonize.py
@@ -343,7 +343,7 @@ def set_mpl_colors(mpl_colors, rgba):
         i = _set_colors_from_array(key, mpl_colors[key], rgba, i)
 
 
-def _prepare_call_sim(fig, color_deficit): # pylint: disable=missing-docstring
+def _prepare_and_call_sim(fig, color_deficit): # pylint: disable=missing-docstring
     mpl_colors = get_mpl_colors(fig)
     rgb, alpha = arrays_from_dict(mpl_colors)
     sim_rgb = simulate(array_to_img(rgb * 255), color_deficit) / 255
@@ -383,10 +383,9 @@ def simulate_mpl(fig, color_deficit='d', copy=False):
     if copy:
         # mpl.transforms cannot be copy.deepcopy()ed. Thus we resort
         # to pickling.
-        # Turns out PolarAffine cannot be unpickled ...
         pfig = pickle.dumps(fig)
         fig = pickle.loads(pfig)
-    sim_rgb, _, alpha, mpl_colors = _prepare_call_sim(fig, color_deficit)
+    sim_rgb, _, alpha, mpl_colors = _prepare_and_call_sim(fig, color_deficit)
     rgba = _join_rgb_alpha(sim_rgb, alpha)
     set_mpl_colors(mpl_colors, rgba)
     fig.canvas.draw()
@@ -415,10 +414,9 @@ def daltonize_mpl(fig, color_deficit='d', copy=False):
     if copy:
         # mpl.transforms cannot be copy.deepcopy()ed. Thus we resort
         # to pickling.
-        # Turns out PolarAffine cannot be unpickled ...
         pfig = pickle.dumps(fig)
         fig = pickle.loads(pfig)
-    sim_rgb, rgb, alpha, mpl_colors = _prepare_call_sim(fig, color_deficit)
+    sim_rgb, rgb, alpha, mpl_colors = _prepare_and_call_sim(fig, color_deficit)
     dtpn = daltonize(rgb, sim_rgb)
     rgba = _join_rgb_alpha(dtpn, alpha)
     set_mpl_colors(mpl_colors, rgba)

--- a/daltonize.py
+++ b/daltonize.py
@@ -12,7 +12,7 @@ from collections import OrderedDict
 try:
     import pickle
 except ImportError:
-    import cPickle as pickle
+    import cPickle as pickle # pylint: disable=import-error
 
 from PIL import Image
 import numpy as np


### PR DESCRIPTION
Unify the calling interface of the pixel image and matplotlib routines.

This creates a tiny overhead if a pixel image is first simulated and then daltonized.

Add docstrings for all external routines and make some clean-ups suggested by PyLint. Also rename one function to better explain what it does.
