### PR TITLE
Convert RGBA images to RGB to prevent exception

### DIFF
--- a/daltonize.py
+++ b/daltonize.py
@@ -106,6 +106,7 @@ def daltonize(rgb, color_deficit='d'):
     # rgb - sim_rgb contains the color information that dichromats
     # cannot see. err2mod rotates this to a part of the spectrum that
     # they can see.
+    rgb = rgb.convert('RGB')
     err = transform_colorspace(rgb - sim_rgb, err2mod)
     dtpn = err + rgb
     return dtpn


### PR DESCRIPTION
Trying to convert a PNG image with an alpha channel causes subtracting rgb and sim_rgb to throw an exception. Added line to convert original image to RGB.
